### PR TITLE
Add Rabbitmq configuration to all services

### DIFF
--- a/item-service/build.gradle
+++ b/item-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compile 'org.springframework.boot:spring-boot-starter-amqp'
     runtime 'org.postgresql:postgresql:42.2.5'
     compileOnly 'org.projectlombok:lombok:1.18.4'
     annotationProcessor 'org.projectlombok:lombok:1.18.4'

--- a/item-service/src/main/java/com/microservices/item/configuration/RabbitConfiguration.java
+++ b/item-service/src/main/java/com/microservices/item/configuration/RabbitConfiguration.java
@@ -4,6 +4,8 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,6 +25,11 @@ public class RabbitConfiguration {
     @Bean
     public Binding binding(DirectExchange directExchange, Queue queue) {
         return BindingBuilder.bind(queue).to(directExchange).with("item");
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 
 }

--- a/item-service/src/main/java/com/microservices/item/configuration/RabbitConfiguration.java
+++ b/item-service/src/main/java/com/microservices/item/configuration/RabbitConfiguration.java
@@ -1,0 +1,28 @@
+package com.microservices.item.configuration;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfiguration {
+
+    @Bean
+    public DirectExchange directExchange() {
+        return new DirectExchange("directExchange");
+    }
+
+    @Bean
+    public Queue queue() {
+        return  new Queue("qitem");
+    }
+
+    @Bean
+    public Binding binding(DirectExchange directExchange, Queue queue) {
+        return BindingBuilder.bind(queue).to(directExchange).with("item");
+    }
+
+}

--- a/item-service/src/main/java/com/microservices/item/controller/ItemController.java
+++ b/item-service/src/main/java/com/microservices/item/controller/ItemController.java
@@ -3,11 +3,10 @@ package com.microservices.item.controller;
 
 import com.microservices.item.dto.ItemCreationDto;
 import com.microservices.item.dto.ItemDto;
-import com.microservices.item.entity.ItemEntity;
+import com.microservices.item.dto.OrderItemDto;
 import com.microservices.item.service.ItemService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +23,7 @@ public class ItemController {
     private final ItemService itemService;
 
     private static final Logger logger = LoggerFactory.getLogger(ItemController.class);
+
 
     @Autowired
     public ItemController(ItemService itemService) {
@@ -56,8 +56,8 @@ public class ItemController {
     }
 
     @RabbitListener(queues = "qitem")
-    public void returnItems(Message message) {
-        logger.info("*********************" + message.toString());
+    public void returnItems(List<OrderItemDto> items) {
+        logger.info("********************* Received items count=" + items.size());
     }
 
 }

--- a/item-service/src/main/java/com/microservices/item/controller/ItemController.java
+++ b/item-service/src/main/java/com/microservices/item/controller/ItemController.java
@@ -5,6 +5,11 @@ import com.microservices.item.dto.ItemCreationDto;
 import com.microservices.item.dto.ItemDto;
 import com.microservices.item.entity.ItemEntity;
 import com.microservices.item.service.ItemService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,10 +17,14 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
+@EnableRabbit
 @RestController
 @RequestMapping("/item")
 public class ItemController {
     private final ItemService itemService;
+
+    private static final Logger logger = LoggerFactory.getLogger(ItemController.class);
+
     @Autowired
     public ItemController(ItemService itemService) {
         this.itemService = itemService;
@@ -44,6 +53,11 @@ public class ItemController {
     @PutMapping("{id}/decreasing/{amount}")
     public ItemDto decreaseAmount(@PathVariable long amount, @PathVariable long id) {
         return itemService.decreaseAmount(id, amount);
+    }
+
+    @RabbitListener(queues = "qitem")
+    public void returnItems(Message message) {
+        logger.info("*********************" + message.toString());
     }
 
 }

--- a/item-service/src/main/java/com/microservices/item/controller/ItemController.java
+++ b/item-service/src/main/java/com/microservices/item/controller/ItemController.java
@@ -57,7 +57,7 @@ public class ItemController {
 
     @RabbitListener(queues = "qitem")
     public void returnItems(List<OrderItemDto> items) {
-        logger.info("********************* Received items count=" + items.size());
+        logger.info("Received items count=" + items.size());
     }
 
 }

--- a/item-service/src/main/java/com/microservices/item/dto/OrderItemDto.java
+++ b/item-service/src/main/java/com/microservices/item/dto/OrderItemDto.java
@@ -1,0 +1,25 @@
+package com.microservices.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor // For Jackson2JsonMessageConverter
+@AllArgsConstructor
+public class OrderItemDto {
+
+    private int id;
+
+    private int itemId;
+
+    private int amount;
+
+    private String name;
+
+    private BigDecimal price;
+}

--- a/item-service/src/main/resources/application.properties
+++ b/item-service/src/main/resources/application.properties
@@ -1,5 +1,7 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/onlineshop
-spring.datasource.username=shop_user
-spring.datasource.password=1234
+server.port=8083
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/online_shop?currentSchema=item_schema
+spring.datasource.username=postgres
+spring.datasource.password=123
 spring.jpa.generate-ddl=true
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true

--- a/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
+++ b/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
@@ -15,31 +15,31 @@ import org.springframework.context.annotation.Configuration;
 public class RabbitConfiguration {
 
     @Bean
-    public ConnectionFactory getConnectionFactory() {
+    public ConnectionFactory connectionFactory() {
         return new CachingConnectionFactory("localhost");
     }
 
     @Bean
-    public DirectExchange getDirectExchange() {
+    public DirectExchange directExchange() {
         return new DirectExchange("exchange");
     }
 
     @Bean
-    public Queue getOrderQueue() {
+    public Queue orderQueue() {
         return  new Queue("qorder");
     }
 
     @Bean
-    public Binding getBinding() {
-        DirectExchange exchange = getDirectExchange();
-        Queue queue = getOrderQueue();
+    public Binding binding() {
+        DirectExchange exchange = directExchange();
+        Queue orderQueue = orderQueue();
         String routingKey = "order";
-        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
+        return BindingBuilder.bind(orderQueue).to(exchange).with(routingKey);
     }
 
     @Bean
-    public RabbitTemplate getRabbitTemplate() {
-        ConnectionFactory connectionFactory = getConnectionFactory();
+    public RabbitTemplate rabbitTemplate() {
+        ConnectionFactory connectionFactory = connectionFactory();
         return new RabbitTemplate(connectionFactory);
     }
 }

--- a/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
+++ b/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -45,8 +47,16 @@ public class RabbitConfiguration {
     }
 
     @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
     public RabbitTemplate rabbitTemplate() {
         ConnectionFactory connectionFactory = connectionFactory();
-        return new RabbitTemplate(connectionFactory);
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+
+        return rabbitTemplate;
     }
 }

--- a/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
+++ b/order-service/src/main/java/com/microservices/order/configuration/RabbitConfiguration.java
@@ -21,20 +21,27 @@ public class RabbitConfiguration {
 
     @Bean
     public DirectExchange directExchange() {
-        return new DirectExchange("exchange");
+        return new DirectExchange("directExchange");
     }
 
     @Bean
-    public Queue orderQueue() {
-        return  new Queue("qorder");
+    public Queue paymentQueue() {
+        return  new Queue("qpayment");
     }
 
     @Bean
-    public Binding binding() {
-        DirectExchange exchange = directExchange();
-        Queue orderQueue = orderQueue();
-        String routingKey = "order";
-        return BindingBuilder.bind(orderQueue).to(exchange).with(routingKey);
+    public Queue itemQueue() {
+        return new Queue("qitem");
+    }
+
+    @Bean
+    public Binding bindingPayment(DirectExchange directExchange, Queue paymentQueue) {
+        return BindingBuilder.bind(paymentQueue).to(directExchange).with("payment");
+    }
+
+    @Bean
+    public Binding bindItems(DirectExchange directExchange, Queue itemQueue) {
+        return BindingBuilder.bind(itemQueue).to(directExchange).with("item");
     }
 
     @Bean

--- a/order-service/src/main/java/com/microservices/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/microservices/order/controller/OrderController.java
@@ -78,12 +78,11 @@ public class OrderController {
         throw new IllegalArgumentException("I need help of payment-service to perform payment, but I cannot communicate with it :(");
     }
 
-    @RabbitListener(queues = "qorder")
-    public void handleMessage(String message) {
-       logger.info(message);
+    public void cancelPayment(int orderId) {
+        rabbitTemplate.convertAndSend("directExchange", "payment", "Cancel payment with orderId=" + orderId);
     }
 
-    public void testSend(int orderId) {
-        rabbitTemplate.convertAndSend("exchange", "order", "I am able to send message with orderId =" + orderId);
+    public void returnItems(int orderId) {
+        rabbitTemplate.convertAndSend("directExchange", "item", "Return items with orderId=" + orderId);
     }
 }

--- a/order-service/src/main/java/com/microservices/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/microservices/order/controller/OrderController.java
@@ -28,7 +28,11 @@ public class OrderController {
     private static final Logger logger = LoggerFactory.getLogger(OrderController.class);
 
     @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
     private OrderService orderService;
+
 
     @GetMapping
     public List<OrderDto> getAllOrders(){
@@ -39,7 +43,6 @@ public class OrderController {
     public OrderDto getOrderById(
         @PathVariable int orderId){
 
-        testSend(orderId);
         return orderService.getOrderById(orderId);
     }
 
@@ -79,9 +82,6 @@ public class OrderController {
     public void handleMessage(String message) {
        logger.info(message);
     }
-
-    @Autowired
-    private RabbitTemplate rabbitTemplate;
 
     public void testSend(int orderId) {
         rabbitTemplate.convertAndSend("exchange", "order", "I am able to send message with orderId =" + orderId);

--- a/order-service/src/main/java/com/microservices/order/controller/OrderController.java
+++ b/order-service/src/main/java/com/microservices/order/controller/OrderController.java
@@ -2,19 +2,16 @@ package com.microservices.order.controller;
 
 import com.microservices.order.dto.ItemChangeAmountDto;
 import com.microservices.order.dto.OrderDto;
+import com.microservices.order.dto.OrderItemDto;
 import com.microservices.order.dto.UserDetailsDto;
 import com.microservices.order.entity.OrderStatus;
 import com.microservices.order.service.OrderService;
-import com.microservices.order.service.OrderServiceImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.amqp.core.AmqpTemplate;
-import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 
 import java.util.List;
@@ -25,13 +22,14 @@ import java.util.Optional;
 @RequestMapping("api/orders")
 public class OrderController {
 
+    @Autowired
+    private OrderService orderService;
+
     private static final Logger logger = LoggerFactory.getLogger(OrderController.class);
 
     @Autowired
     private RabbitTemplate rabbitTemplate;
 
-    @Autowired
-    private OrderService orderService;
 
 
     @GetMapping
@@ -66,7 +64,14 @@ public class OrderController {
         @PathVariable int orderId,
         @PathVariable OrderStatus orderStatus) {
 
-        return orderService.setOrderStatus(orderId, orderStatus);
+        OrderDto orderDto = orderService.setOrderStatus(orderId, orderStatus);
+        if (orderStatus == OrderStatus.CANCELED) {
+            List<OrderItemDto> itemsToReturn = orderDto.getItems();
+            returnItems(itemsToReturn);
+            cancelPayment(orderId);
+        }
+
+        return orderDto;
     }
 
     @PutMapping(value = "{orderId}/payment")
@@ -79,10 +84,12 @@ public class OrderController {
     }
 
     public void cancelPayment(int orderId) {
-        rabbitTemplate.convertAndSend("directExchange", "payment", "Cancel payment with orderId=" + orderId);
+        rabbitTemplate.convertAndSend("directExchange", "payment", orderId);
+        logger.info("Send message to payment with orderId=" + orderId);
     }
 
-    public void returnItems(int orderId) {
-        rabbitTemplate.convertAndSend("directExchange", "item", "Return items with orderId=" + orderId);
+    public void returnItems(List<OrderItemDto> items) {
+        rabbitTemplate.convertAndSend("directExchange", "item", items);
+        logger.info("Send message to item with items count=" + items.size());
     }
 }

--- a/order-service/src/main/resources/application.properties
+++ b/order-service/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-server.port = 8081
+server.port=8081
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/online_shop?currentSchema=order_schema
 spring.jpa.generate-ddl=true

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compile 'org.springframework.boot:spring-boot-starter-amqp'
     compile "io.springfox:springfox-swagger2:2.9.2"
     compile "io.springfox:springfox-swagger-ui:2.9.2"
     runtime 'org.postgresql:postgresql:42.2.5'

--- a/payment-service/src/main/java/com/microservices/payment/configuration/RabbitConfiguration.java
+++ b/payment-service/src/main/java/com/microservices/payment/configuration/RabbitConfiguration.java
@@ -1,0 +1,31 @@
+package com.microservices.payment.configuration;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitConfiguration {
+
+    @Bean
+    public DirectExchange directExchange() {
+        return new DirectExchange("directExchange");
+    }
+
+    @Bean
+    public Queue queue() {
+        return  new Queue("qpayment");
+    }
+
+    @Bean
+    public Binding binding(DirectExchange directExchange, Queue queue) {
+        return BindingBuilder.bind(queue).to(directExchange).with("payment");
+    }
+
+}

--- a/payment-service/src/main/java/com/microservices/payment/configuration/RabbitConfiguration.java
+++ b/payment-service/src/main/java/com/microservices/payment/configuration/RabbitConfiguration.java
@@ -4,9 +4,6 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/payment-service/src/main/java/com/microservices/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/microservices/payment/controller/PaymentController.java
@@ -3,15 +3,23 @@ package com.microservices.payment.controller;
 import com.microservices.payment.dto.PaymentCreationDto;
 import com.microservices.payment.dto.PaymentDto;
 import com.microservices.payment.service.PaymentService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 
 import javax.validation.Valid;
 
+@EnableRabbit
 @RestController
 @RequestMapping("payment")
 public class PaymentController {
     private PaymentService paymentService;
+
+    private static final Logger logger = LoggerFactory.getLogger(PaymentController.class);
 
     @Autowired
     public PaymentController(PaymentService paymentService) {
@@ -38,4 +46,9 @@ public class PaymentController {
         return paymentService.cancelPayment(payment_id);
     }
 
+
+    @RabbitListener(queues = "qpayment")
+    public void cancelPayment(Message message) {
+        logger.info("*********************" + message.toString());
+    }
 }

--- a/payment-service/src/main/java/com/microservices/payment/controller/PaymentController.java
+++ b/payment-service/src/main/java/com/microservices/payment/controller/PaymentController.java
@@ -42,13 +42,15 @@ public class PaymentController {
     }
 
     @PutMapping(value = "{payment_id}/cancel")
-    public PaymentDto cancelPayment(@PathVariable int payment_id) {
+    public PaymentDto cancelPaymentByPaymentId(@PathVariable int payment_id) {
         return paymentService.cancelPayment(payment_id);
     }
 
 
     @RabbitListener(queues = "qpayment")
-    public void cancelPayment(Message message) {
-        logger.info("*********************" + message.toString());
+    public void cancelPaymentByOrderId(Message message) {
+        String orderIdString = new String(message.getBody());
+        int orderId = Integer.parseInt(orderIdString);
+        logger.info("Received order id to cancel payment. orderId=" + orderId);
     }
 }

--- a/payment-service/src/main/resources/application.properties
+++ b/payment-service/src/main/resources/application.properties
@@ -1,11 +1,8 @@
 server.port=8082
 
-database.schema.name=payment_service
-
-spring.datasource.url=jdbc:postgresql://localhost:5432/online_shop
+spring.datasource.url=jdbc:postgresql://localhost:5432/online_shop?currentSchema=payment_schema
 spring.datasource.username=postgres
 spring.datasource.password=123
 spring.jpa.generate-ddl=true
 
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
-spring.jpa.properties.hibernate.default_schema=${database.schema.name}

--- a/payment-service/src/main/resources/application.properties
+++ b/payment-service/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=8082
+
 database.schema.name=payment_service
 
 spring.datasource.url=jdbc:postgresql://localhost:5432/online_shop


### PR DESCRIPTION
@lembolov9, @saltowl, you need to implement functionality to cancel payment and return items to warehouse. Me and @ElenaOstrikova implement interaction between order-service, payment-service and item-service through RabbitMQ queues and write listeners methods with logging in your services without any useful actions. You can use constants in these methods instead of input parameters to check do them work correct, if you wouldn't use RabbitMQ real interaction.

@lembolov9, also we slightly changed application.properties in your service to be able to run it. If it not bother you, could you please save that configuration and accordingly change your database properties (at least database name, user and password)